### PR TITLE
Ensure 1d inputs as np arrays

### DIFF
--- a/dtwalign/dtw.py
+++ b/dtwalign/dtw.py
@@ -81,8 +81,12 @@ def dtw(x, y, dist="euclidean", window_type="none", window_size=None,
     """
     len_x = x.shape[0]; len_y = y.shape[0]
     # if 1D array, convert to 2D array
-    if x.ndim == 1: x = x[:, np.newaxis]
-    if y.ndim == 1: y = y[:, np.newaxis]
+    if x.ndim == 1:
+        x = np.array(x)
+        x = x[:, np.newaxis]
+    if y.ndim == 1:
+        y = np.array(y)
+        y = y[:, np.newaxis]
 
     # get pair-wise cost matrix
     if type(dist) == str:


### PR DESCRIPTION
# Update numpy array indexing convention in response to  Pandas 1.0.0 future warnings:

This update ensures 1D inputs to the module are in a numpy format. This is to adress the future warning raised in Pandas 1.0.0 + updates. 

Specifically:

"Support for multi-dimensional indexing (e.g. index[:, None]) on a Index is deprecated and will be removed in a future version, convert to a numpy array before indexing instead (GH30588)" (https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.0.0.html)


